### PR TITLE
Create: GET /class_counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,4 +100,5 @@ upstream	git@github.com:NBNARADHYA/bosch-inter-iit.git (push)
 5. The above command could be run in detached mode with `-d` flag as
    `docker-compose up -d`.
 6. To install new dependencies to `web`, run `docker-compose run web yarn add <pkg_name>`
-7. For help, run the command `docker-compose -h`.
+7. When updated code is pulled, delete the volume (only if `web` has changed) by running `docker volume rm bosch-inter-iit_node_modules_web` before running `docker-compose up --build`.
+8. For help, run the command `docker-compose -h`.


### PR DESCRIPTION
### Changes
1. Create `GET /class_counts` to get class counts for each class. The response will be returned in the following format.
    ```
     {
       "class_counts": {
         "00001": {
           "counts": 24
         },
         "00005": {
           "counts": 11
         }
       }
     }
    ```
2. `POST /split_dataset` changed to return response in the following format.
    ```
     {
       "done": true,
       "csv": {
         "train": "http://localhost:5000/train_val_csv/b8f696c8-7f06-479a-ad80-8bb372bca5bf_train.csv",
         "val": "http://localhost:5000/train_val_csv/b8f696c8-7f06-479a-ad80-8bb372bca5bf_val.csv"
       },
       "class_counts": {
         "train": {
           "00001": {
             "counts": 18
           },
           "00005": {
             "counts": 8
           }
         },
         "val": {
           "00001": {
             "counts": 6
           },
           "00005": {
             "counts": 3
           }
         }
       }
     }
    ```
3. `POST /transform_images` changed to accept string values for `class_id`.