### PR TITLE
Change: start script of fastapi docker

### DIFF
--- a/services/server/Dockerfile.dev
+++ b/services/server/Dockerfile.dev
@@ -9,3 +9,5 @@ ENV SERVER_BASE_URL="http://localhost:5000/"
 
 RUN apt-get update
 RUN apt-get install -y libgl1-mesa-dev
+
+CMD /start-reload.sh


### PR DESCRIPTION
### Changes
1. Change start script of `server` service to `/start-reload.sh` instead of the default start script.