### PR TITLE
link ResultApp with backend and add navbar

### DIFF
--- a/services/server/main.py
+++ b/services/server/main.py
@@ -5,7 +5,7 @@ import uuid
 from io import BytesIO
 from typing import List
 from typing import Optional
-
+import cv2
 import albumentations as A
 import augmentations
 import folder_actions

--- a/services/web/src/App.js
+++ b/services/web/src/App.js
@@ -1,14 +1,90 @@
 import React from "react";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
-
+import { makeStyles, useTheme } from "@material-ui/core/styles";
 import DatasetApp from "./DatasetApp/App";
 import ResultApp from "./ResultApp/App";
+
+
+const drawerWidth = 360;
+
+const useStyles = makeStyles((theme) => ({
+  "@global": {
+    "*::-webkit-scrollbar": {
+      width: "0.5em",
+    },
+    "*::-webkit-scrollbar-track": {
+      "-webkit-box-shadow": "inset 0 0 6px rgba(0,0,0,0.00)",
+    },
+    "*::-webkit-scrollbar-thumb": {
+      backgroundColor: "#757575",
+      outline: "1px solid #757575",
+    },
+  },
+  root: {
+    display: "flex",
+  },
+  appBar: {
+    transition: theme.transitions.create(["margin", "width"], {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen,
+    }),
+  },
+  appBarShift: {
+    width: `calc(100% - ${drawerWidth}px)`,
+    marginLeft: drawerWidth,
+    transition: theme.transitions.create(["margin", "width"], {
+      easing: theme.transitions.easing.easeOut,
+      duration: theme.transitions.duration.enteringScreen,
+    }),
+  },
+  menuButton: {
+    marginRight: theme.spacing(2),
+  },
+  hide: {
+    display: "none",
+  },
+  drawer: {
+    width: drawerWidth,
+    flexShrink: 0,
+  },
+  drawerPaper: {
+    width: drawerWidth,
+  },
+  drawerHeader: {
+    display: "flex",
+    alignItems: "center",
+    padding: theme.spacing(0, 1),
+    // necessary for content to be below app bar
+    ...theme.mixins.toolbar,
+    justifyContent: "flex-end",
+  },
+  content: {
+    flexGrow: 1,
+    padding: theme.spacing(3),
+    transition: theme.transitions.create("margin", {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen,
+    }),
+    marginLeft: -drawerWidth,
+  },
+  contentShift: {
+    transition: theme.transitions.create("margin", {
+      easing: theme.transitions.easing.easeOut,
+      duration: theme.transitions.duration.enteringScreen,
+    }),
+    marginLeft: 0,
+  },
+}));
+
 function App() {
+  const theme = useTheme();
+  const classes = useStyles();
+
   return (
     <Router>
       <Switch>
-        <Route path="/result" component={ResultApp} />
-        <Route component={DatasetApp} />        
+        <Route path="/evaluate" component={() => <ResultApp classes={classes} theme={theme} />} />
+        <Route component={() => <DatasetApp classes={classes} theme={theme} />}/>        
       </Switch>
     </Router>
   );

--- a/services/web/src/DatasetApp/App.js
+++ b/services/web/src/DatasetApp/App.js
@@ -1,5 +1,4 @@
 import CssBaseline from "@material-ui/core/CssBaseline";
-import { makeStyles, useTheme } from "@material-ui/core/styles";
 import React from "react";
 import { Route, Switch } from "react-router-dom";
 import { useLocation } from "react-router-dom";
@@ -7,81 +6,8 @@ import ApplyTransformations from "./pages/ApplyTransformations";
 import BalanceDatasetPage from "./pages/BalanceDataset";
 import SplitDatasetPage from "./pages/SplitDataset";
 
-const drawerWidth = 360;
 
-const useStyles = makeStyles((theme) => ({
-  "@global": {
-    "*::-webkit-scrollbar": {
-      width: "0.5em",
-    },
-    "*::-webkit-scrollbar-track": {
-      "-webkit-box-shadow": "inset 0 0 6px rgba(0,0,0,0.00)",
-    },
-    "*::-webkit-scrollbar-thumb": {
-      backgroundColor: "#757575",
-      outline: "1px solid #757575",
-    },
-  },
-  root: {
-    display: "flex",
-  },
-  appBar: {
-    transition: theme.transitions.create(["margin", "width"], {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.leavingScreen,
-    }),
-  },
-  appBarShift: {
-    width: `calc(100% - ${drawerWidth}px)`,
-    marginLeft: drawerWidth,
-    transition: theme.transitions.create(["margin", "width"], {
-      easing: theme.transitions.easing.easeOut,
-      duration: theme.transitions.duration.enteringScreen,
-    }),
-  },
-  menuButton: {
-    marginRight: theme.spacing(2),
-  },
-  hide: {
-    display: "none",
-  },
-  drawer: {
-    width: drawerWidth,
-    flexShrink: 0,
-  },
-  drawerPaper: {
-    width: drawerWidth,
-  },
-  drawerHeader: {
-    display: "flex",
-    alignItems: "center",
-    padding: theme.spacing(0, 1),
-    // necessary for content to be below app bar
-    ...theme.mixins.toolbar,
-    justifyContent: "flex-end",
-  },
-  content: {
-    flexGrow: 1,
-    padding: theme.spacing(3),
-    transition: theme.transitions.create("margin", {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.leavingScreen,
-    }),
-    marginLeft: -drawerWidth,
-  },
-  contentShift: {
-    transition: theme.transitions.create("margin", {
-      easing: theme.transitions.easing.easeOut,
-      duration: theme.transitions.duration.enteringScreen,
-    }),
-    marginLeft: 0,
-  },
-}));
-
-const App = () => {
-  const classes = useStyles();
-  
-  const theme = useTheme();
+const App = ({classes, theme}) => {
   const { pathname } = useLocation();
 
   return (

--- a/services/web/src/DatasetApp/components/Navbar.js
+++ b/services/web/src/DatasetApp/components/Navbar.js
@@ -13,7 +13,7 @@ import Zoom from '@material-ui/core/Zoom';
 import MenuIcon from "@material-ui/icons/Menu";
 import MenuItem from '@material-ui/core/MenuItem';
 import Menu from '@material-ui/core/Menu';
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 
 const useStyles = makeStyles(theme => ({
@@ -21,6 +21,9 @@ const useStyles = makeStyles(theme => ({
   },
   menuOptions: {
     marginLeft: 'auto'
+  },
+  uiMenuOptions: {
+    float: "left"
   },  
   dropdownText: {
     margin: theme.spacing(0, 0.5, 0, 1)
@@ -44,19 +47,41 @@ const menuOptions = [{
 }
 ];
 
-export default function Navbar({ classes, open, handleDrawerOpen, toggleTimelineDrawer, openTour }) {
-const navbarClasses = useStyles();
-const [anchorEl, setAnchorEl] = React.useState(null);
-const isMenuOpen = Boolean(anchorEl);
-const handleMenu = (event) => {
-  setAnchorEl(event.currentTarget);
-};
-const currentPath = window.location.pathname;
-const handleClose = () => {
-  setAnchorEl(null);
-};
+const uiOptions = [
+  {
+    text: 'Dataset Creation UI',
+    links: menuOptions.map(({link}) => link),
+    link: "/"
+  },
+  {
+    text: 'Post Evaluation UI',
+    links: ['/evaluate'],
+    link: "/evaluate"
+  }
+]
 
-const selectedOption = menuOptions.filter(({link}) => link===currentPath)[0].text;
+export default function Navbar({ classes, open, handleDrawerOpen, toggleTimelineDrawer, openTour }) {
+  const navbarClasses = useStyles();
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  const isMenuOpen = Boolean(anchorEl);
+  const [uiAnchorEl, setUIAnchorEl] = React.useState(null);
+  const isUIMenuOpen = Boolean(uiAnchorEl);
+  const handleMenu = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const currentPath = useLocation().pathname;
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+  
+  let selectedUIOption = uiOptions.filter(({links}) => links.some(link => currentPath === link))[0]
+  if(selectedUIOption) selectedUIOption = selectedUIOption.text;
+
+  let selectedOption = menuOptions.filter(({link}) => link===currentPath)[0]; 
+  if( selectedOption ) {
+    selectedOption = selectedOption.text;
+  }
+
   return (
     <AppBar
       position="fixed"
@@ -74,36 +99,66 @@ const selectedOption = menuOptions.filter(({link}) => link===currentPath)[0].tex
         >
           <MenuIcon />
         </IconButton>}
-        <Typography variant="h6" noWrap>
-          Dataset Creation UI
-        </Typography>
-        <Button color="inherit" onClick={handleMenu}  aria-haspopup="true" className={navbarClasses.menuOptions} id="step9">
+        <Button color="inherit" onClick={(e) => setUIAnchorEl(e.currentTarget)}  aria-haspopup="true" className={navbarClasses.uiMenuOptions} id="step9">
           <span className={navbarClasses.dropdownText}>
-          {selectedOption}
-          <ExpandMoreIcon fontSize="small" className={navbarClasses.dropdownIcon} />          
+            {selectedUIOption}
+            <ExpandMoreIcon fontSize="small" className={navbarClasses.dropdownIcon} />          
           </span>
-        </Button>        
+        </Button>
         <Menu
-          id="menu-appbar"
-          anchorEl={anchorEl}
+          anchorEl={uiAnchorEl}
           getContentAnchorEl={null}
           anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
           transformOrigin={{ vertical: "top", horizontal: "center" }}
-          open={isMenuOpen}
-          onClose={handleClose}
+          open={isUIMenuOpen}
+          onClose={() => setUIAnchorEl(null)}
         >
-          {menuOptions.map(({text,link},i) =>  <MenuItem
+          {uiOptions.map(({text,link, links},i) =>  <MenuItem
                   component={Link}
                   data-no-link="true"
                   to={link}
                   key={i.toString()}
-                  selected={currentPath === link}
-                  onClick={handleClose}
+                  selected={links.some(link => currentPath === link)}
+                  onClick={() => setUIAnchorEl(null)}
                 >
                   {text}
                 </MenuItem>)
               }
         </Menu>
+        {/* <Typography variant="h6" noWrap>
+          Dataset Creation UI
+        </Typography> */}
+        {selectedUIOption === "Dataset Creation UI" &&
+          <>
+            <Button color="inherit" onClick={handleMenu}  aria-haspopup="true" className={navbarClasses.menuOptions} id="step9">
+              <span className={navbarClasses.dropdownText}>
+              {selectedOption}
+              <ExpandMoreIcon fontSize="small" className={navbarClasses.dropdownIcon} />          
+              </span>
+            </Button>
+            <Menu
+              id="menu-appbar"
+              anchorEl={anchorEl}
+              getContentAnchorEl={null}
+              anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+              transformOrigin={{ vertical: "top", horizontal: "center" }}
+              open={isMenuOpen}
+              onClose={handleClose}
+            >
+              {menuOptions.map(({text,link},i) =>  <MenuItem
+                      component={Link}
+                      data-no-link="true"
+                      to={link}
+                      key={i.toString()}
+                      selected={currentPath === link}
+                      onClick={handleClose}
+                    >
+                      {text}
+                    </MenuItem>)
+                  }
+            </Menu>
+          </>
+        }     
         {selectedOption==='Apply transformations' && 
         <>
         <Tooltip TransitionComponent={Zoom} title="Timeline of applied augmentations">        

--- a/services/web/src/DatasetApp/pages/BalanceDataset.js
+++ b/services/web/src/DatasetApp/pages/BalanceDataset.js
@@ -185,8 +185,11 @@ function BalanceDataset(props) {
                 <Button disabled={loading} color="primary" onClick={() => {
                   setLoading(true)
                   setOpen(false)
-                  let data = new FormData()
-                  data.append('min_samples',minSamples)
+                  let data
+                  if(minSamples !== null) {
+                    let data = new FormData()
+                    data.append('min_samples',minSamples)
+                  }
                   fetch(`${serverUrl}balance_dataset`, { method: "POST", body: data })
                   .then(res => res.json())
                   .then(res => {

--- a/services/web/src/ResultApp/App.js
+++ b/services/web/src/ResultApp/App.js
@@ -1,11 +1,129 @@
-import React from "react";
+import React, { useCallback, useEffect, useState } from "react";
+import serverUrl from "../Constants/serverUrl";
 import TabPanel from "./TabPanel";
+import Backdrop from '@material-ui/core/Backdrop';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { makeStyles } from "@material-ui/core/styles";
+import FormControl from '@material-ui/core/FormControl';
+import Select from '@material-ui/core/Select';
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
+import { Typography, Button } from '@material-ui/core'
+import Navbar from "../DatasetApp/components/Navbar";
 
-const App = () => {
+const useStyles = makeStyles((theme) => ({
+  backdrop: {
+    zIndex: theme.zIndex.drawer + 1,
+    color: '#fff',
+  },
+  formControl: {
+    margin: theme.spacing(1),
+    minWidth: 300,
+  },
+}))
+
+const App = (props) => {
+
+  const [modelName, setModelName] = useState(null)
+  const [model, setModel] = useState(null)
+  const [models, setModels] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [modelIdx, setModelIdx] = useState("")
+  const [modelOutput, setModelOutput] = useState(null)
+
+  let classes = useStyles()
+  classes = { ...classes, ...props.classes }
+  const theme = props.theme
+
+  useEffect(() => {
+    setLoading(true)
+    fetch(`${serverUrl}models`)
+    .then(res => res.json())
+    .then(res => {
+      setModels(res.models)
+      setLoading(false)
+    })
+    .catch(console.error)
+  }, [])
+
+  useEffect(() => {
+    models.length && modelIdx !== "" && setModelName(models[modelIdx])
+  }, [modelIdx, models])
+
+  const handleFileUpload = useCallback((e) => {
+    setModel(e.target.files[0])
+  }, [])
+
+  useEffect(() => {
+    if (!modelName && !model)  return
+
+    const formData = new FormData()
+
+    if (modelName) {
+      formData.append("model_name", modelName)
+    } else {
+      formData.append("model", model)
+    }
+
+    setLoading(true)
+
+    fetch(`${serverUrl}model_output`, {
+      method: "POST",
+      body: formData
+    })
+    .then(res => res.json())
+    .then(res => {
+      if(res.model_name === undefined) res.model_name = modelName
+      setModelOutput(res)
+      setLoading(false)
+    })
+    .catch(console.error)
+  }, [model, modelName])
+
   return (
-    <div>
-      <TabPanel />
-    </div>
+    <>
+      <Navbar
+        classes={classes}
+        open={false}
+        theme={theme}
+       />
+       <div className={classes.drawerHeader} />
+      <Backdrop className={classes.backdrop} open={loading}>
+        <CircularProgress color="primary" />
+      </Backdrop>
+      {models.length && !modelOutput &&
+        <>
+          <FormControl className={classes.formControl}>
+            <InputLabel>Previously uploaded models</InputLabel>
+            <Select
+              value={modelIdx}
+              onChange={(e) => setModelIdx(e.target.value)}
+            >
+              {models.map((model, idx) => (
+                <MenuItem key={idx} value={idx}>{model}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <br />
+          <Typography variant="h5">OR</Typography>
+          <br />
+          <Button
+            variant="contained"
+            component="label"
+          >
+            Upload Model
+            <input
+              type="file"
+              onChange={handleFileUpload}
+              hidden
+            />
+          </Button>
+        </>
+      }
+      {modelOutput && 
+        <TabPanel {...modelOutput} />
+      }
+    </>
   );
 };
 

--- a/services/web/src/ResultApp/TabPanel/ConfidenceClasses/index.js
+++ b/services/web/src/ResultApp/TabPanel/ConfidenceClasses/index.js
@@ -17,7 +17,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const ConfidenceClasses = () => {
+const ConfidenceClasses = (props) => {
   const classes = useStyles();
   const [descriptionBox, setDescriptionBox] = React.useState(false);
   const handleDescriptionOpen = () => setDescriptionBox(true);

--- a/services/web/src/ResultApp/TabPanel/index.js
+++ b/services/web/src/ResultApp/TabPanel/index.js
@@ -44,7 +44,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default function TabsWrappedLabel() {
+export default function TabsWrappedLabel(props) {
   const classes = useStyles();
   const [value, setValue] = React.useState(0);
 
@@ -67,9 +67,20 @@ export default function TabsWrappedLabel() {
       </AppBar>{" "}
       {tabs.map(({ component }, idx) => (
         <TabPanel key={idx} value={value} index={idx}>
-          {component()}
+          {component(props)}
         </TabPanel>
       ))}
     </div>
   );
+}
+
+TabsWrappedLabel.propTypes = {
+  model_name: PropTypes.string.isRequired,
+  train_metrics: PropTypes.object.isRequired,
+  test_metrics: PropTypes.object.isRequired,
+  top_5_classes: PropTypes.object.isRequired,
+  wrong_pred: PropTypes.array.isRequired,
+  confusion_matrix_path: PropTypes.string.isRequired,
+  wrost_acc_classes: PropTypes.object.isRequired,
+  most_confused_classes: PropTypes.array.isRequired,
 }

--- a/services/web/src/ResultApp/TabPanel/tabs.js
+++ b/services/web/src/ResultApp/TabPanel/tabs.js
@@ -1,11 +1,11 @@
 import ConfidenceClasses from "./ConfidenceClasses";
 import ConfusedClasses from "./ConfusedClasses";
 import ConfusionMatrix from "./ConfusionMatrix";
-import TestModel from "./TestModel";
+// import TestModel from "./TestModel";
 
 export const tabs = [
-  { name: "Confidence classes", component: () => <ConfidenceClasses /> },
-  { name: "Confused classes", component: () => <ConfusedClasses /> },
-  { name: "Confusion Matrix", component: () => <ConfusionMatrix /> },
-  { name: "Test Model", component: () => <TestModel /> },
+  { name: "Confidence classes", component: (props) => <ConfidenceClasses {...props} /> },
+  { name: "Confused classes", component: (props) => <ConfusedClasses {...props} /> },
+  { name: "Confusion Matrix", component: (props) => <ConfusionMatrix {...props} /> },
+  // { name: "Test Model", component: (props) => <TestModel {...props} /> },
 ];


### PR DESCRIPTION
### Changes
1. Link `ResultApp` with the backend. (The response will be available in the `props` of each `tab` component)
2. Add dropdown menu in the navbar to navigate between `Data Creation UI` and `Post Evaluation UI`.
3. Move `classes` from `DatasetApp` to main `App` component.